### PR TITLE
fix:passwordResetリクエストボディredirect_urlを追加

### DIFF
--- a/src/lib/hooks/useAuth.ts
+++ b/src/lib/hooks/useAuth.ts
@@ -115,21 +115,25 @@ export const useAuth = () => {
     };
 
     // パスワードリセット
-    const passwordReset = async (email: string) => {
-        setLoading(true);
-        setError(null);
-        setSuccess(null);
+   const passwordReset = async (email: string) => {
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
 
-        try {
-            await axiosInstance.post("/auth/password", { email });
-            setSuccess("パスワードリセットメールが送信されました。メールを確認してください。");
-        } catch (e) {
-            setError("パスワードリセットのリクエストに失敗しました");
-        } finally {
-            setLoading(false);
-        }
-    };
+    try {
+        await axiosInstance.post("/auth/password", {
+            email,
+            redirect_url: process.env.NEXT_PUBLIC_REDIRECT_URL
+        });
+        setSuccess("パスワードリセットメールが送信されました。メールを確認してください。");
+    } catch (e) {
+        setError("パスワードリセットのリクエストに失敗しました");
+    } finally {
+        setLoading(false);
+    }
+};
 
+    
     // パスワードリセット確認
     const resetPasswordConfirm = async (
         password: string,


### PR DESCRIPTION
## 概要

<!-- このプルリクエストで何を実装・修正したのか具体的に記載してください -->

- `front/src/lib/hooks/useAuth.ts` のpasswordResetにリクエストボディredirect_urlを追加

## 関連Issue

[[https://github.com/users/sora2525/projects/3?pane=issue&itemId=90828281&issue=sora2525|Portfolio|31](https://github.com/users/sora2525/projects/3?pane=issue&itemId=90828281&issue=sora2525%7CPortfolio%7C31)](https://github.com/users/sora2525/projects/3?pane=issue&itemId=90828281&issue=sora2525%7CPortfolio%7C31)

## スクリーンショット（任意）

## 参考資料

<!-- 参考にした資料やURLがあれば記載 -->

- https://footlog-blog.net/posts/20220103-the-event-of-no-redirection-by-resetting-the-password-of-devise_token_auth/

## 備考

<!-- その他、レビュアーに伝えたいことがあれば記載 -->

- 今回の修正により影響がありそうな箇所: ユーザー登録・ログイン
- 本番環境に表示されるかの懸念材料がある部分等