### PR TITLE
fix:searchParamsをreset_password_tokenに変更

### DIFF
--- a/src/app/password-reset/page.tsx
+++ b/src/app/password-reset/page.tsx
@@ -5,7 +5,7 @@ import { useAuth } from "@/lib/hooks/useAuth";
 
 interface PasswordResetProps {
     searchParams: {
-        token?: string;
+        reset_password_token?: string;
     };
 }
 
@@ -28,7 +28,7 @@ const PasswordReset = ({ searchParams }: PasswordResetProps) => {
         await resetPasswordConfirm(
             newPassword,
             confirmPassword,
-            searchParams.token ?? "", 
+            searchParams.reset_password_token ?? "", 
         );
     };
 


### PR DESCRIPTION
## 概要

<!-- このプルリクエストで何を実装・修正したのか具体的に記載してください -->

- `src/app/password-reset/page.tsx` クエリパラメータの変更によりsearchParamsを変更

```ruby

interface PasswordResetProps {
    searchParams: {
        reset_password_token?: string;
    };
}
```

## 関連Issue

## スクリーンショット（任意）

## 参考資料

<!-- 参考にした資料やURLがあれば記載 -->

## 備考

<!-- その他、レビュアーに伝えたいことがあれば記載 -->