### PR TITLE
Fix/use search params

### DIFF
--- a/src/app/password-reset/page.tsx
+++ b/src/app/password-reset/page.tsx
@@ -1,16 +1,14 @@
+// PasswordReset.tsx
 'use client';
 export const dynamic = "force-dynamic";
 import { useState } from "react";
+import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/hooks/useAuth";
 
-interface PasswordResetProps {
-    searchParams: {
-        reset_password_token?: string;
-    };
-}
-
-const PasswordReset = ({ searchParams }: PasswordResetProps) => {
+const PasswordReset = () => {
     const { success, error, loading, resetPasswordConfirm } = useAuth();
+    const searchParams = useSearchParams();
+    const resetToken = searchParams.get("reset_password_token") || "";
 
     const [newPassword, setNewPassword] = useState<string>("");
     const [confirmPassword, setConfirmPassword] = useState<string>("");
@@ -25,11 +23,7 @@ const PasswordReset = ({ searchParams }: PasswordResetProps) => {
             return;
         }
 
-        await resetPasswordConfirm(
-            newPassword,
-            confirmPassword,
-            searchParams.reset_password_token ?? "", 
-        );
+        await resetPasswordConfirm(newPassword, confirmPassword, resetToken);
     };
 
     return (

--- a/src/app/password-reset/page.tsx
+++ b/src/app/password-reset/page.tsx
@@ -1,11 +1,12 @@
 // PasswordReset.tsx
 'use client';
 export const dynamic = "force-dynamic";
-import { useState } from "react";
+
+import { useState, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/hooks/useAuth";
 
-const PasswordReset = () => {
+const PasswordResetForm = () => {
     const { success, error, loading, resetPasswordConfirm } = useAuth();
     const searchParams = useSearchParams();
     const resetToken = searchParams.get("reset_password_token") || "";
@@ -20,6 +21,11 @@ const PasswordReset = () => {
 
         if (newPassword !== confirmPassword) {
             setLocalError("パスワードが一致しません。");
+            return;
+        }
+
+        if (!resetToken) {
+            setLocalError("パスワードリセットトークンが無効です。");
             return;
         }
 
@@ -67,6 +73,15 @@ const PasswordReset = () => {
                 </form>
             </div>
         </div>
+    );
+};
+
+// SuspenseでPasswordResetFormをラップ
+const PasswordReset = () => {
+    return (
+        <Suspense fallback={<div className="text-center mt-8">読み込み中...</div>}>
+            <PasswordResetForm />
+        </Suspense>
     );
 };
 


### PR DESCRIPTION
PasswordResetForm コンポーネントを作成し、パスワードリセットフォームを分離。
Suspense で PasswordResetForm をラップし、useSearchParams 使用時にサスペンスエラーが発生しないよう修正。