### PR TITLE
fix:googleSessionコンポーネントのリダイレクト先を修正

### DIFF
--- a/src/components/GoogleLogin.tsx
+++ b/src/components/GoogleLogin.tsx
@@ -11,7 +11,7 @@ export default function LoginButton() {
       // Google認証を実行 (リダイレクト無効化)
       const result = await authSignIn("google", {
         redirect: true,
-        callbackUrl: "session/google",
+        callbackUrl: "/session/google",
         prompt: "select_account",
       });
 


### PR DESCRIPTION
/抜けを修正
```

      const result = await authSignIn("google", {
        redirect: true,
        callbackUrl: "session/google",
        callbackUrl: "/session/google",
        prompt: "select_account",
      });

```